### PR TITLE
pyprojectに複数のpythonpathを設定しても1つしか利かない？

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+pythonpath = ["app/function/module_a","app/function/module_b"]


### PR DESCRIPTION
```
[tool.pytest.ini_options]
pythonpath = ["app/function/module_a","app/function/module_b"]
```
のように設定しているのでmodule_a,module_bとも読み込まれるべき？だが、module_bが呼ばれない

![image](https://github.com/user-attachments/assets/3e5bbf3c-54a1-4021-96b3-2f3a6b89a9a1)

```
[tool.pytest.ini_options]
pythonpath = ["app/function/module_b","app/function/module_a"]
```
のようにb,aの順で設定するとaが読み込まれないので、最初に設定したもののみが呼ばれていそう？
![image](https://github.com/user-attachments/assets/91e3e7cd-f377-443c-bb9f-1653de69f11f)

